### PR TITLE
Add volumeMount

### DIFF
--- a/deployment.yaml
+++ b/deployment.yaml
@@ -36,6 +36,9 @@ spec:
           value: "true"
         ports:
         - containerPort: 80
+        volumeMounts:                  # Add this section
+        - name: vaultwarden
+          mountPath: /data             # Mount the volume at /data
       volumes:
       - name: vaultwarden
         persistentVolumeClaim:


### PR DESCRIPTION
You need to mount the storage provided by longhorn (defined by the PVC) into the container. For Vaultwarden, common mount paths are /data for the SQLite DB and possibly /config for configuration files, depending on your setup.